### PR TITLE
Improve directory picker and scan result display

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -60,6 +60,19 @@ def index_page():
         page_size_default=PAGE_SIZE_DEFAULT
     )
 
+# -------------------- 列举子目录 --------------------
+@bp.get("/ls")
+def list_dirs():
+    scan_dir = request.values.get("dir", DEFAULT_SCAN_DIR)
+    if not is_under_allowed_roots(scan_dir):
+        return jsonify({"ok": False, "error": "目录不在允许的根目录内"}), 400
+    try:
+        p = Path(scan_dir)
+        subs = [str(child) for child in p.iterdir() if child.is_dir()]
+        return jsonify({"ok": True, "subs": subs})
+    except Exception:
+        return jsonify({"ok": False, "error": "目录列举失败"}), 500
+
 # -------------------- 文件扫描 --------------------
 @bp.get("/scan")
 def scan():

--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -186,7 +186,10 @@
 
     const selected=exts?exts.split(","):[];
     renderRows(j, selected);
-    $("#pageinfo").textContent=`本页 ${($$("#tbl tbody tr").length)} 项 · 接口 ${res.u}`;
+    const total=Number(j.total||0);
+    const pages=total?Math.ceil(total/pageSize):0;
+    $("#count").textContent=total?`${total} 个文件，共 ${pages} 页`:"未扫描";
+    $("#pageinfo").textContent=`本页 ${($$("#tbl tbody tr").length)} 项`;
   }
 
   function renderRows(payload, selectedExts){
@@ -197,13 +200,14 @@
       const ext=getExt(it);
       if(selectedExts.length && !selectedExts.includes(ext)) return;
       const full=getFullPath(it);
+      const dir=it.dir_path||it.dir||it.directory||it.path_dir||"";
       const sizeKB=humanKBFromAny(it.size_kb ?? it.sizeKB ?? it.size_bytes ?? it.size ?? it.bytes);
       const mtime=parseMTime(it);
       const tr=document.createElement("tr");
       tr.innerHTML=`
         <td><input type="checkbox" class="ck" data-path="${full}"></td>
         <td>${it.name||it.filename||""}</td>
-        <td>${full}</td>
+        <td>${dir}</td>
         <td>${ext}</td>
         <td>${it.category||""}</td>
         <td>${sizeKB}</td>


### PR DESCRIPTION
## Summary
- add `/ls` endpoint to enumerate subdirectories
- show total file count and pages after scanning
- display directory path only and remove debug URL from page info

## Testing
- `python -m py_compile api/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3c23b0b74832988bc29cde66ae3d5