### PR TITLE
Fix state file path to state.json

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1,18 +1,19 @@
 import json
 from pathlib import Path
 
-SETTINGS_PATH = Path(__file__).parent.parent / "config/settings.json"
+STATE_PATH = Path(__file__).parent.parent / "state.json"
 
-def load_settings():
-    if SETTINGS_PATH.exists():
-        with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+
+def load_state():
+    if STATE_PATH.exists():
+        with open(STATE_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
-    else:
-        return {}
+    return {}
 
-def save_settings(data):
-    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
 
-SETTINGS = load_settings()
+STATE = load_state()
+
+
+def save_state():
+    with open(STATE_PATH, "w", encoding="utf-8") as f:
+        json.dump(STATE, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- Correct `core.state` to read/write `state.json` instead of `config/settings.json`
- Expose `save_state()` to persist the global `STATE`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a52a47eb4c8329ac71acbe379d1306