### PR TITLE
Fix login and directory listing

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -61,6 +61,20 @@ def index_page():
         page_size_default=PAGE_SIZE_DEFAULT
     )
 
+@bp.get("/ls")
+def list_dirs():
+    base = request.args.get("dir")
+    if base:
+        if not is_under_allowed_roots(base):
+            return jsonify({"ok": False, "error": "目录不在允许的根目录内"}), 400
+        try:
+            subs = [str(p) for p in Path(base).iterdir() if p.is_dir()]
+        except Exception as e:
+            return jsonify({"ok": False, "error": str(e)}), 400
+    else:
+        subs = ALLOWED_ROOTS
+    return jsonify({"ok": True, "subs": subs})
+
 @bp.get("/scan")
 def scan():
     scan_dir = request.values.get("dir", DEFAULT_SCAN_DIR)

--- a/app_unified.py
+++ b/app_unified.py
@@ -2,6 +2,7 @@
 import os
 from urllib.parse import urlencode
 from flask import Flask, request, abort, redirect, jsonify, session
+from core.settings import SETTINGS
 
 # 你的蓝图（保持现有路径）
 from api.ai import bp as ai_bp            # /api/ai/*
@@ -30,6 +31,11 @@ def _redirect_with_args(target_path: str, params: dict | None):
 
 def create_app() -> Flask:
     app = Flask(__name__, template_folder="templates", static_folder="static")
+    app.secret_key = (
+        SETTINGS.get("auth", {}).get("secret_key")
+        or os.environ.get("SECRET_KEY")
+        or "groundhog-secret"
+    )
 
     # --------------------------- Blueprint Registration ---------------------------
     # /api/ai/* 直接保留

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,7 +1,8 @@
 {
   "auth": {
     "admin_username": "admin",
-    "admin_password": "admin"
+    "admin_password": "admin",
+    "secret_key": "change-me"
   },
   "permissions": {
     "admin": 1

--- a/core/state.py
+++ b/core/state.py
@@ -1,18 +1,19 @@
 import json
 from pathlib import Path
 
-SETTINGS_PATH = Path(__file__).parent.parent / "config/settings.json"
+STATE_PATH = Path(__file__).parent.parent / "state.json"
 
-def load_settings():
-    if SETTINGS_PATH.exists():
-        with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+
+def load_state():
+    if STATE_PATH.exists():
+        with open(STATE_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
-    else:
-        return {}
+    return {}
 
-def save_settings(data):
-    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
 
-SETTINGS = load_settings()
+STATE = load_state()
+
+
+def save_state():
+    with open(STATE_PATH, "w", encoding="utf-8") as f:
+        json.dump(STATE, f, indent=2, ensure_ascii=False)

--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -180,14 +180,14 @@
 
     let j=null;
     try{ j=await res.r.json(); }catch(e){ toggleLoading(false); customConfirm("响应解析失败").then(()=>{}); return; }
-    toggleLoading(false);
+      toggleLoading(false);
 
-    if(!j || !j.ok){ customConfirm("接口返回错误").then(()=>{}); return; }
+      if(!j || !j.ok){ customConfirm("接口返回错误").then(()=>{}); return; }
 
-    const selected=exts?exts.split(","):[];
-    renderRows(result.data, selected);
-    $("#pageinfo").textContent=`本页 ${($$("#tbl tbody tr").length)} 项 · 接口 ${result.url}`;
-  }
+      const selected=exts?exts.split(","):[];
+      renderRows(j, selected);
+      $("#pageinfo").textContent=`本页 ${($$("#tbl tbody tr").length)} 项 · 接口 ${res.u}`;
+    }
 
   function renderRows(payload, selectedExts){
     const tbody=$("#tbl tbody"); if(!tbody) return;

--- a/templates/full.html
+++ b/templates/full.html
@@ -215,59 +215,5 @@
     </div>
   </div>
 </div>
-
-<script>
-document.addEventListener("DOMContentLoaded", () => {
-  // 添加 设置按钮
-  const topbar = document.querySelector(".topbar");
-  const settingsBtn = document.createElement("button");
-  settingsBtn.textContent = "⚙️ 设置";
-  settingsBtn.className = "btn btn-sm";
-  settingsBtn.style.marginLeft = "12px";
-  settingsBtn.onclick = () => {
-    document.getElementById("settingsModal").style.display = "flex";
-  };
-  topbar?.appendChild(settingsBtn);
-
-  // 设置关闭按钮
-  document.getElementById("settingsClose")?.addEventListener("click", () => {
-    document.getElementById("settingsModal").style.display = "none";
-  });
-
-  // 登录按钮（可选添加）
-  const loginBtn = document.createElement("button");
-  loginBtn.textContent = "🔐 登录";
-  loginBtn.className = "btn btn-sm";
-  loginBtn.onclick = () => {
-    document.getElementById("loginModal").style.display = "flex";
-  };
-  topbar?.appendChild(loginBtn);
-
-  // 登录确认事件
-  document.getElementById("loginConfirm")?.addEventListener("click", async () => {
-    const username = document.getElementById("loginUser").value.trim();
-    const password = document.getElementById("loginPass").value.trim();
-    const res = await fetch("/full/login", {
-      method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({username, password})
-    });
-    const j = await res.json();
-    if (j.ok) {
-      alert("登录成功");
-      document.getElementById("loginModal").style.display = "none";
-      location.reload();
-    } else {
-      alert("登录失败：" + (j.error || "未知错误"));
-    }
-  });
-
-  // 登录取消
-  document.getElementById("loginCancel")?.addEventListener("click", () => {
-    document.getElementById("loginModal").style.display = "none";
-  });
-});
-</script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Flask secret key from settings to enable session-based login
- Implement `/full/ls` endpoint for directory picker
- Remove duplicate inline login/settings script and fix scan results rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52a47eb4c8329ac71acbe379d1306