### PR TITLE
feat(ui): group feature toggles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -25,3 +25,5 @@ th,td{border-bottom:1px solid #eee;padding:8px;text-align:left}
 .grid{display:grid;grid-template-columns:repeat(auto-fill, minmax(120px, 1fr));gap:8px}
 .card{border:1px solid #eee;border-radius:8px;padding:8px}
 .small{font-size:12px;color:#666}
+.feature-grid{display:flex;gap:20px}
+.feature-grid>div{flex:1}

--- a/templates/full.html
+++ b/templates/full.html
@@ -68,7 +68,8 @@
   .section-title{ font-weight:600; margin:10px 0 6px; }
   .small-muted{ color:#666; font-size:12px; }
   </style>
-</head>
+  </head>
+<body data-user="{{ session.get('user', '') }}">
   <div class="topbar">
     <div class="topbar-left">
       <img class="logo" src="/static/logo.png" alt="logo">
@@ -256,5 +257,44 @@
           <div class="small-muted">说明：本地 Ollama 不需要 API Key；远程 AI 需要。</div>
         </div>
 
+        <div style="margin-top: 12px;">
+          <div class="section-title">功能权限开关</div>
+          <div class="feature-grid">
+            <div>
+              <label class="pill"><input type="checkbox" id="feat_text" checked> 文字类型</label>
+              <label class="pill"><input type="checkbox" id="feat_data" checked> 数据类型</label>
+              <label class="pill"><input type="checkbox" id="feat_slides" checked> 简报类型</label>
+              <label class="pill"><input type="checkbox" id="feat_pdf" checked> PDF 类型</label>
+              <label class="pill"><input type="checkbox" id="feat_archive" checked> 压缩类型</label>
+              <label class="pill"><input type="checkbox" id="feat_image" checked> 图片类型</label>
+              <label class="pill"><input type="checkbox" id="feat_video"> 视频类型</label>
+              <label class="pill"><input type="checkbox" id="feat_audio"> 音频类型</label>
+            </div>
+            <div>
+              <label class="pill"><input type="checkbox" id="feat_ai_keywords" checked> AI 关键词提取</label>
+              <label class="pill"><input type="checkbox" id="feat_move" checked> 移动</label>
+              <label class="pill"><input type="checkbox" id="feat_rename" checked> 重命名</label>
+              <label class="pill"><input type="checkbox" id="feat_delete" checked> 删除</label>
+              <label class="pill"><input type="checkbox" id="feat_image_caption"> 图像反向提示词</label>
+              <label class="pill"><input type="checkbox" id="feat_video_preview"> 视频预览</label>
+              <label class="pill"><input type="checkbox" id="feat_audio_preview"> 音频预览</label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-foot" style="justify-content:flex-end;">
+        <button class="btn" id="settingsSave">保存设置</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 全局加载层 -->
+  <div id="loading" class="loader" aria-hidden="true">
+    <div class="spinner hourglass"></div>
+    <div class="loading-text">正在处理，请稍候…</div>
+  </div>
+
+  <!-- 带版本号避免缓存 -->
+  <script src="/static/app_classic.js?v=20250820b"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Organize settings feature checkboxes into separate file-type and operation columns
- Add CSS to layout the feature groups in parallel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a575f576348329bc41c2fccc22ba66