### PR TITLE
Improve AI provider and model settings

### DIFF
--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -233,10 +233,42 @@
 
   function updateAIFields(){
     const p=$('#aiProvider')?.value;
-    if(p==='ollama'){
-      $('#aiApiKey').style.display='none';
+    const url=$('#aiUrl');
+    const key=$('#aiApiKey');
+    const urlDiv=url?.parentElement;
+    const keyDiv=key?.parentElement;
+    const modelSel=$('#aiModel');
+
+    if(keyDiv) keyDiv.style.display=(p==='ollama')?'none':'block';
+    if(urlDiv) urlDiv.style.display='block';
+
+    if(p==='deepseek'){
+      if(url) url.required=true;
+      if(key) key.required=true;
+    }else if(p==='chatgpt'){
+      if(url) url.required=false;
+      if(key) key.required=true;
     }else{
-      $('#aiApiKey').style.display='block';
+      if(url) url.required=false;
+      if(key) key.required=false;
+    }
+
+    if(modelSel){
+      const prev=modelSel.value;
+      modelSel.innerHTML='';
+      let models=[];
+      if(p==='ollama'){
+        models=['qwen2.5:latest','llama2','mistral'];
+      }else if(p==='chatgpt'){
+        models=['gpt-3.5-turbo','gpt-4','gpt-4o'];
+      }else if(p==='deepseek'){
+        models=['deepseek-chat','deepseek-coder'];
+      }
+      models.forEach(m=>{
+        const o=document.createElement('option');
+        o.value=m; o.textContent=m; modelSel.appendChild(o);
+      });
+      if(prev) modelSel.value=prev;
     }
   }
 
@@ -261,8 +293,8 @@
     $('#aiProvider').value = s.ai?.provider || 'ollama';
     $('#aiUrl').value = s.ai?.url || '';
     $('#aiApiKey').value = s.ai?.api_key || '';
-    $('#aiModel').value = s.ai?.model || '';
     updateAIFields();
+    $('#aiModel').value = s.ai?.model || '';
     const f = s.features || {};
     $('#feat_text').checked = !!f.enable_text;
     $('#feat_data').checked = !!f.enable_data;
@@ -351,7 +383,10 @@
       const s = await res.json();
       if(s.theme){ $$('input[name="theme"]').forEach(r=>r.checked=(r.value===s.theme)); }
       if($('#aiProvider')) $('#aiProvider').value = s.ai?.provider || 'ollama';
-      if($('#apiKey')) $('#apiKey').value = s.ai?.api_key || '';
+      if($('#aiUrl')) $('#aiUrl').value = s.ai?.url || '';
+      if($('#aiApiKey')) $('#aiApiKey').value = s.ai?.api_key || '';
+      updateAIFields();
+      if($('#aiModel')) $('#aiModel').value = s.ai?.model || '';
 
       const f = s.features || {};
       const map = {
@@ -387,7 +422,9 @@
       theme: ($$('input[name="theme"]:checked')[0]?.value)||'system',
       ai:{
         provider: $('#aiProvider')?.value || 'ollama',
-        api_key: $('#apiKey')?.value?.trim() || ''
+        url: $('#aiUrl')?.value?.trim() || '',
+        api_key: $('#aiApiKey')?.value?.trim() || '',
+        model: $('#aiModel')?.value || ''
       },
       features:{
         enable_text: !!$('#feat_text')?.checked,

--- a/templates/full.html
+++ b/templates/full.html
@@ -242,15 +242,23 @@
           <div class="grid-2">
             <div>
               <label>AI 供应商：</label>
-              <select id="aiProvider" style="min-width:180px;">
+              <select id="aiProvider" style="min-width:180px;" onchange="updateAIFields()">
                 <option value="ollama">Ollama（本地）</option>
                 <option value="chatgpt">OpenAI / ChatGPT</option>
                 <option value="deepseek">DeepSeek</option>
               </select>
             </div>
             <div>
+              <label>API URL：</label>
+              <input id="aiUrl" placeholder="接口地址" style="min-width:260px;">
+            </div>
+            <div>
               <label>API Key：</label>
-              <input id="apiKey" type="password" placeholder="如使用远程 AI，请填写 API Key" style="min-width:260px;">
+              <input id="aiApiKey" type="password" placeholder="如使用远程 AI，请填写 API Key" style="min-width:260px;">
+            </div>
+            <div>
+              <label>模型：</label>
+              <select id="aiModel" style="min-width:180px;"></select>
             </div>
           </div>
           <div class="small-muted">说明：本地 Ollama 不需要 API Key；远程 AI 需要。</div>


### PR DESCRIPTION
## Summary
- Expand `updateAIFields` to manage URL/API key visibility, requirements, and provider-specific model lists
- Call `updateAIFields` after initializing AI settings in `openSettings`
- Rework settings modal template so model list is populated dynamically

## Testing
- `pytest`
- `node --check static/app_classic.js` *(fails: SyntaxError: Invalid left-hand side in assignment)*

------
https://chatgpt.com/codex/tasks/task_e_68a575f766ec83298ed701b1b9d6c624