### PR TITLE
fix: restore type filters and login controls

### DIFF
--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -283,7 +283,8 @@
       tr.style.display = ok ? '' : 'none';
     });
     const visible = rows.filter(tr=>tr.style.display!=='none').length;
-    $("#pageinfo")?.textContent=`第 ${currentPage} 页 / 共 ${totalPages} 页 · 本页 ${visible} 项`;
+    const pageInfoEl = $("#pageinfo");
+    if(pageInfoEl){ pageInfoEl.textContent = `第 ${currentPage} 页 / 共 ${totalPages} 页 · 本页 ${visible} 项`; }
   }
 
   async function openSettings(){
@@ -589,6 +590,10 @@
       console.warn('读取设置失败：', e);
       applyFeatureToggles({});
     }
+
+    // 初始化文件类型下拉框并在类别变化时动态更新
+    fillTypes();
+    document.getElementById('category')?.addEventListener('change', fillTypes);
 
     const ut = document.getElementById('userTools');
     if (ut) {

--- a/templates/full.html
+++ b/templates/full.html
@@ -70,13 +70,16 @@
   </style>
   </head>
 <body data-user="{{ session.get('user', '') }}">
-  <div class="topbar">
-    <div class="topbar-left">
-      <img class="logo" src="/static/logo.png" alt="logo">
-      <h2 class="brand">Surprised Groundhog · V1.01</h2>
+    <div class="topbar">
+      <div class="topbar-left">
+        <img class="logo" src="/static/logo.png" alt="logo">
+        <h2 class="brand">Surprised Groundhog · V1.01</h2>
+      </div>
+    <div id="userTools">
+      <button class="btn btn-sm" id="settingsBtn">设置</button>
+      <button class="btn btn-sm" id="loginBtn">登录</button>
     </div>
-    <div id="userTools"></div>
-  </div>
+    </div>
 
   <div class="row">
     <label for="category">档案种类：</label>


### PR DESCRIPTION
## Summary
- ensure file type dropdown populates and updates with chosen category
- fix JS syntax so login logic runs and add default login/settings buttons

## Testing
- `node --check static/app_classic.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a57e7fc66c83298c82746914be372a