### PR TITLE
fix: enable local Ollama keywords and bind buttons

### DIFF
--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -247,7 +247,14 @@
       modelSel.innerHTML='';
       let models=[];
       if(p==='ollama'){
-        try{ const r=await fetch('/api/ai/ollama/models',{credentials:'include'}); const j=await r.json(); models=j.models||[]; }catch(e){ models=[]; }
+        try{
+          const r=await fetch('/api/ai/ollama/models',{credentials:'include'});
+          const j=await r.json();
+          models=j.models||[];
+        }catch(e){ models=[]; }
+        if(models.length===0){
+          models=['gpt-oss:20b','deepseek-r1:14b','llama3.1:latest'];
+        }
       }else if(p==='chatgpt'){
         models=['gpt-3.5-turbo','gpt-4','gpt-4o'];
       }else if(p==='deepseek'){
@@ -519,6 +526,10 @@
     // 预览（事件委托）
     const tbody=$('#tbl tbody');
     if(tbody) tbody.addEventListener('click', onPreview);
+
+    // 固定按钮绑定（HTML 已包含时直接绑定）
+    bind('#settingsBtn','click', openSettings);
+    bind('#loginBtn','click', ()=>{ $('#loginModal') && ($('#loginModal').style.display='flex'); });
 
     // 顶部工具区：若未在 HTML 放固定按钮，这里兜底加入“设置/登录”
     const topbar = document.querySelector('.topbar');


### PR DESCRIPTION
## Summary
- Read AI config from settings and support custom model/URL for Ollama keyword extraction
- Provide fallback model list and bind existing settings/login buttons on the classic UI

## Testing
- `python -m py_compile core/ollama.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e054651c83298767bce337b81018