### PR TITLE
Fix missing requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ mysql-connector-python==9.0.0
 python-pptx==0.6.23
 rarfile==4.2
 py7zr==0.21.0
+requests==2.31.0
+Send2Trash==1.8.2


### PR DESCRIPTION
## Summary
- Add requests and Send2Trash to requirements to match runtime imports

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests==2.31.0)*
- `python app_unified.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b9e1a2948329a516ee29f93fd2b2