### PR TITLE
Improve table layout and keyword display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -32,7 +32,7 @@ th,td{border-bottom:1px solid #eee;padding:8px;text-align:left}
 .fixed-table th,.fixed-table td{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .col-select{width:42px}
 .col-name{width:220px}
-.col-path{width:320px}
+.col-path{width:260px}
 .col-ext{width:90px}
 .col-category{width:120px}
 .col-size{width:100px}
@@ -41,3 +41,10 @@ th,td{border-bottom:1px solid #eee;padding:8px;text-align:left}
 .col-move{width:160px}
 .col-rename{width:160px}
 .col-preview{width:80px}
+
+/* Allow keywords column to wrap and show full content */
+.fixed-table td.kw{
+  white-space:normal;
+  word-break:break-all;
+  overflow:visible;
+}

--- a/templates/full.html
+++ b/templates/full.html
@@ -73,7 +73,7 @@
     <select id="types" multiple size="6" style="min-width: 160px;"></select>
 
     <label for="dir">扫描目录：</label>
-    <input id="dir" type="text" value="{{ default_dir }}" placeholder="请选择要扫描的目录…" style="min-width: 420px;">
+    <input id="dir" type="text" value="{{ default_dir }}" placeholder="请选择要扫描的目录…" style="min-width: 300px;">
     <button class="btn" id="pickDir">选择目录</button>
 
     <label class="pill"><input id="hash" type="checkbox" {% if enable_hash_default %}checked{% endif %}> 计算 SHA256</label>


### PR DESCRIPTION
## Summary
- Narrow directory path input to keep layout within screen width
- Reduce table path column width and allow keyword column to wrap so full results show

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a812c16c008329bbbb7cbf5c875f57