### PR TITLE
Add hybrid retrieval skeleton and unified search endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6,6 +6,7 @@ import os, io, csv, shutil, json, re, textwrap, math
 import requests
 from PIL import Image
 from send2trash import send2trash
+from services.retrieval import HybridRetriever
 
 from core.config import (
     ALLOWED_ROOTS, DEFAULT_SCAN_DIR, ENABLE_HASH_DEFAULT, PAGE_SIZE_DEFAULT,
@@ -27,6 +28,7 @@ except Exception:  # pragma: no cover - 如果依赖缺失
     kw_fast = kw_embed = kw_llm = compose_keywords = None
 
 bp = Blueprint("full_api", __name__)
+retriever = HybridRetriever()
 
 # -------------------- 本地分类（含 zip/rar/7z ） --------------------
 CATEGORIES_LOCAL = {
@@ -509,9 +511,28 @@ def thumb():
             buf = io.BytesIO()
             im.save(buf, format="JPEG")
             buf.seek(0)
-            return send_file(buf, mimetype="image/jpeg")
+    return send_file(buf, mimetype="image/jpeg")
     except Exception:
         abort(404)
+
+# -------------------- 检索接口 --------------------
+@bp.post("/search")
+def search():
+    """Unified search endpoint.
+
+    The request body follows a subset of the Chroma API with fields such as
+    ``query``, ``k``, ``where`` and ``where_document``.
+    """
+
+    p = request.get_json() or {}
+    hits = retriever.query(
+        [p.get("query", "")],
+        k=p.get("k", 10),
+        where=p.get("where"),
+        where_document=p.get("where_document"),
+        search_type=p.get("search_type", "hybrid"),
+    )
+    return jsonify({"results": hits})
 
 # -------------------- 登录/登出 --------------------
 @bp.post("/login")

--- a/services/retrieval/__init__.py
+++ b/services/retrieval/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight retrieval service layer.
+
+This package provides a minimal local implementation of a hybrid search
+pipeline inspired by the Chroma API.  It is intentionally small and keeps
+all data in memory so that the surrounding application can evolve without a
+heavy dependency footprint.
+"""
+
+from .hybrid import HybridRetriever
+
+__all__ = ["HybridRetriever"]

--- a/services/retrieval/bm25_local.py
+++ b/services/retrieval/bm25_local.py
@@ -1,0 +1,69 @@
+"""Very small in-memory keyword matcher.
+
+The implementation is *not* a full BM25 algorithm; it merely counts term
+frequency for the supplied query terms.  The goal is to provide a zero
+dependency baseline that mirrors the API of a more sophisticated backend.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, Any, Iterable, List
+
+from .retriever import Hit, Retriever
+from .filters import match_where, match_where_document
+
+
+class BM25Local(Retriever):
+    def __init__(self) -> None:
+        self._docs: Dict[str, Dict[str, Any]] = {}
+
+    # Retriever interface -------------------------------------------------
+    def upsert(self, chunks: Iterable[Dict[str, Any]]) -> int:
+        count = 0
+        for ch in chunks:
+            self._docs[ch["id"]] = ch
+            count += 1
+        return count
+
+    def delete(self, ids: List[str]) -> int:
+        removed = 0
+        for i in ids:
+            if i in self._docs:
+                del self._docs[i]
+                removed += 1
+        return removed
+
+    def query(
+        self,
+        query_texts: List[str],
+        k: int = 10,
+        where: Dict[str, Any] | None = None,
+        where_document: Dict[str, Any] | None = None,
+        search_type: str = "keyword",
+    ) -> List[Hit]:
+        if not query_texts:
+            return []
+        terms = query_texts[0].split()
+        scores = []
+        for ch in self._docs.values():
+            if not match_where(ch.get("metadata", {}), where):
+                continue
+            if not match_where_document(ch.get("text", ""), where_document):
+                continue
+            cnt = Counter(ch.get("text", "").split())
+            score = sum(cnt[t] for t in terms)
+            if score:
+                scores.append((score, ch))
+        scores.sort(key=lambda x: x[0], reverse=True)
+        hits: List[Hit] = []
+        for score, ch in scores[:k]:
+            hits.append(
+                Hit(
+                    id=ch["id"],
+                    document=ch.get("text", ""),
+                    metadata=ch.get("metadata", {}),
+                    score=float(score),
+                    chunk=ch.get("chunk", {}),
+                )
+            )
+        return hits

--- a/services/retrieval/faiss_local.py
+++ b/services/retrieval/faiss_local.py
@@ -1,0 +1,75 @@
+"""Toy vector retriever based on token overlap.
+
+This module mimics the interface of a FAISS-backed retriever but does not
+require external dependencies.  It computes a simple Jaccard similarity over
+word tokens which is sufficient for small demos and unit tests.
+"""
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable, List
+
+from .retriever import Hit, Retriever
+from .filters import match_where, match_where_document
+
+
+class FaissLocal(Retriever):
+    def __init__(self) -> None:
+        self._docs: Dict[str, Dict[str, Any]] = {}
+
+    def _tokenise(self, text: str) -> set[str]:
+        return set(text.split())
+
+    # Retriever interface -------------------------------------------------
+    def upsert(self, chunks: Iterable[Dict[str, Any]]) -> int:
+        count = 0
+        for ch in chunks:
+            ch = dict(ch)
+            ch["_tokens"] = self._tokenise(ch.get("text", ""))
+            self._docs[ch["id"]] = ch
+            count += 1
+        return count
+
+    def delete(self, ids: List[str]) -> int:
+        removed = 0
+        for i in ids:
+            if i in self._docs:
+                del self._docs[i]
+                removed += 1
+        return removed
+
+    def query(
+        self,
+        query_texts: List[str],
+        k: int = 10,
+        where: Dict[str, Any] | None = None,
+        where_document: Dict[str, Any] | None = None,
+        search_type: str = "vector",
+    ) -> List[Hit]:
+        if not query_texts:
+            return []
+        q_tokens = self._tokenise(query_texts[0])
+        scores = []
+        for ch in self._docs.values():
+            if not match_where(ch.get("metadata", {}), where):
+                continue
+            if not match_where_document(ch.get("text", ""), where_document):
+                continue
+            t = ch.get("_tokens", set())
+            if not t:
+                continue
+            score = len(q_tokens & t) / len(q_tokens | t)
+            if score:
+                scores.append((score, ch))
+        scores.sort(key=lambda x: x[0], reverse=True)
+        hits: List[Hit] = []
+        for score, ch in scores[:k]:
+            hits.append(
+                Hit(
+                    id=ch["id"],
+                    document=ch.get("text", ""),
+                    metadata=ch.get("metadata", {}),
+                    score=float(score),
+                    chunk=ch.get("chunk", {}),
+                )
+            )
+        return hits

--- a/services/retrieval/filters.py
+++ b/services/retrieval/filters.py
@@ -1,0 +1,70 @@
+"""Utility helpers for where / where_document filters.
+
+The implementation is intentionally tiny and supports only the operators
+required by the project: ``$and``, ``$or``, ``$in``, ``$gte``, ``$lte``,
+``$gt``, ``$lt``, ``$regex`` and ``$contains``.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+
+def _match_expr(value: Any, expr: Any) -> bool:
+    """Match a single field against an expression."""
+
+    if isinstance(expr, dict):
+        for op, cond in expr.items():
+            if op == "$in":
+                if value not in cond:
+                    return False
+            elif op == "$gt":
+                if not (value > cond):
+                    return False
+            elif op == "$gte":
+                if not (value >= cond):
+                    return False
+            elif op == "$lt":
+                if not (value < cond):
+                    return False
+            elif op == "$lte":
+                if not (value <= cond):
+                    return False
+            elif op == "$regex":
+                if not re.search(str(cond), str(value)):
+                    return False
+            elif op == "$contains":
+                if str(cond) not in str(value):
+                    return False
+            else:  # unknown operator
+                return False
+        return True
+    else:
+        return value == expr
+
+
+def match_where(obj: Dict[str, Any], where: Dict[str, Any] | None) -> bool:
+    """Return True if ``obj`` satisfies ``where`` expression."""
+
+    if not where:
+        return True
+    if "$and" in where:
+        return all(match_where(obj, w) for w in where["$and"])
+    if "$or" in where:
+        return any(match_where(obj, w) for w in where["$or"])
+
+    for field, expr in where.items():
+        if field.startswith("$"):
+            continue
+        if not _match_expr(obj.get(field), expr):
+            return False
+    return True
+
+
+def match_where_document(text: str, where_doc: Dict[str, Any] | None) -> bool:
+    """Evaluate ``where_document`` against text content."""
+
+    if not where_doc:
+        return True
+    # Reuse ``match_where`` by pretending the text is a field named 'document'.
+    return match_where({"document": text}, {"document": where_doc})

--- a/services/retrieval/hybrid.py
+++ b/services/retrieval/hybrid.py
@@ -1,0 +1,49 @@
+"""Hybrid retrieval combining simple vector and keyword search."""
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable, List
+
+from .retriever import Hit, Retriever
+from .faiss_local import FaissLocal
+from .bm25_local import BM25Local
+
+
+class HybridRetriever(Retriever):
+    def __init__(self) -> None:
+        self.vector = FaissLocal()
+        self.keyword = BM25Local()
+
+    def upsert(self, chunks: Iterable[Dict[str, Any]]) -> int:
+        data = list(chunks)
+        self.vector.upsert(data)
+        self.keyword.upsert(data)
+        return len(data)
+
+    def delete(self, ids: List[str]) -> int:
+        removed_vec = self.vector.delete(ids)
+        removed_kw = self.keyword.delete(ids)
+        return max(removed_vec, removed_kw)
+
+    def query(
+        self,
+        query_texts: List[str],
+        k: int = 10,
+        where: Dict[str, Any] | None = None,
+        where_document: Dict[str, Any] | None = None,
+        search_type: str = "hybrid",
+    ) -> List[Hit]:
+        if search_type == "vector":
+            return self.vector.query(query_texts, k, where, where_document)
+        if search_type == "keyword":
+            return self.keyword.query(query_texts, k, where, where_document)
+
+        hits: Dict[str, Hit] = {}
+        for h in self.vector.query(query_texts, k, where, where_document):
+            hits[h["id"]] = h
+        for h in self.keyword.query(query_texts, k, where, where_document):
+            if h["id"] in hits:
+                # favour higher score, keep combined metadata
+                hits[h["id"]]["score"] = max(hits[h["id"]]["score"], h["score"])
+            else:
+                hits[h["id"]] = h
+        return sorted(hits.values(), key=lambda x: x["score"], reverse=True)[:k]

--- a/services/retrieval/retriever.py
+++ b/services/retrieval/retriever.py
@@ -1,0 +1,73 @@
+"""Abstract retrieval interface.
+
+The real implementation is intentionally lightweight.  All data is kept in
+memory and the public interface follows a subset of the Chroma VectorStore
+API so that future backends can drop in with minimal changes.
+"""
+from __future__ import annotations
+
+from typing import Protocol, TypedDict, Iterable, List, Dict, Any
+
+
+class Hit(TypedDict):
+    """Standardised return structure for search results."""
+
+    id: str
+    document: str
+    metadata: Dict[str, Any]
+    score: float
+    chunk: Dict[str, Any]
+
+
+class Retriever(Protocol):
+    """Protocol implemented by all retriever backends."""
+
+    def upsert(self, chunks: Iterable[Dict[str, Any]]) -> int:
+        """Insert or update chunks.
+
+        Parameters
+        ----------
+        chunks:
+            Iterable of dictionaries containing at least ``id`` and ``text``
+            keys.  Additional fields are stored as metadata.
+
+        Returns
+        -------
+        int
+            Number of processed chunks.
+        """
+
+        ...
+
+    def delete(self, ids: List[str]) -> int:
+        """Remove chunks by id.
+
+        Parameters
+        ----------
+        ids:
+            Identifiers to remove.
+
+        Returns
+        -------
+        int
+            Number of removed chunks.
+        """
+
+        ...
+
+    def query(
+        self,
+        query_texts: List[str],
+        k: int = 10,
+        where: Dict[str, Any] | None = None,
+        where_document: Dict[str, Any] | None = None,
+        search_type: str = "hybrid",
+    ) -> List[Hit]:
+        """Query the index.
+
+        Parameters mirror the Chroma API.  The default implementation
+        returns an empty list so that callers can gracefully degrade when a
+        more sophisticated backend is not available.
+        """
+
+        ...


### PR DESCRIPTION
## Summary
- add lightweight retrieval service with vector, keyword and hybrid modes
- support basic where/where_document filters
- expose a `/search` route using the new retriever

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb65509ec8329a1c2dfc8a4f3d3df