### PR TITLE
Refactor retrieval filters and local search

### DIFF
--- a/services/retrieval/faiss_local.py
+++ b/services/retrieval/faiss_local.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Dict, Any, Iterable, List
 
 from .retriever import Hit, Retriever
-from .filters import match_where, match_where_document
+from .filters import build_where, build_where_document
 
 
 class FaissLocal(Retriever):
@@ -48,11 +48,13 @@ class FaissLocal(Retriever):
         if not query_texts:
             return []
         q_tokens = self._tokenise(query_texts[0])
+        meta_pred = build_where(where)
+        doc_pred = build_where_document(where_document)
         scores = []
         for ch in self._docs.values():
-            if not match_where(ch.get("metadata", {}), where):
+            if not meta_pred(ch.get("metadata", {})):
                 continue
-            if not match_where_document(ch.get("text", ""), where_document):
+            if not doc_pred(ch.get("text", "")):
                 continue
             t = ch.get("_tokens", set())
             if not t:


### PR DESCRIPTION
## Summary
- build reusable predicate functions for `$and`, `$or`, `$in`, comparison, regex and substring operators
- precompile `where` filters in local FAISS and BM25 retrievers and add regex-based scoring to BM25

## Testing
- `python -m py_compile services/retrieval/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68afbbd0e8488329be1e5c01f6980d34