### PR TITLE
Add retrieval evaluation script and snapshot utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,34 @@ python app_lan.py
 
 ---
 
-## 常见问题  
+## 常见问题
 - **输入路径**：Windows 用 `D:\Work`，Linux/macOS 用 `/home/user/Work`  
 - **权限问题**：移动/删除操作可能需管理员权限  
 - **扩展名支持**：可在 `scanner.py` 或插件中扩展  
 
 - **关键词记录**：AI 提取结果会保存在 `state.json` 中的 `keywords` 和 `keywords_log` 字段（包含 `tags`），方便调试。
+
+---
+
+## 检索评测与快照导出
+
+### 评测
+准备两个 JSONL 文件：
+
+1. `chunks.jsonl` – 每行一个文档块，至少包含 `id` 和 `text` 字段，用于构建检索索引。
+2. `qa_pairs.jsonl` – 每行一个问答对，包含 `question` 和 `answer_ids`（相关文档块 ID 列表）。
+
+运行评测脚本计算 Recall@k 与 MRR：
+
+```bash
+python scripts/evaluate_retrieval.py --collection chunks.jsonl --pairs qa_pairs.jsonl --k 5
+```
+
+### 导出快照
+将指定集合目录中的 `*.parquet`、`*.index` 以及 `meta.json` 压缩到 `snapshots/`：
+
+```bash
+python -m services.retrieval.hybrid snapshot my_collection
+```
+
+生成的 `snapshots/my_collection.tar.gz` 可用于部署或备份。

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+"""Evaluate retrieval quality against internal QA pairs.
+
+This script expects two JSONL files:
+
+1. A collection of chunks to index, each line containing at least ``id`` and
+   ``text`` fields.  Use ``--collection`` to point at this file.
+2. A file of evaluation questions with a list of relevant ``answer_ids``.
+   Use ``--pairs`` to point at this file.  Example line::
+
+       {"question": "...", "answer_ids": ["doc-1", "doc-2"]}
+
+The script builds an in-memory :class:`HybridRetriever` from the collection and
+computes Recall@k and MRR for the questions.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Dict, Any, List
+
+# allow running as a stand-alone script
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.retrieval import HybridRetriever
+
+
+def load_jsonl(path: Path) -> Iterable[Dict[str, Any]]:
+    """Yield dictionaries from a JSONL file."""
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate retrieval metrics")
+    parser.add_argument(
+        "--collection", required=True, type=Path, help="JSONL file of chunks to index"
+    )
+    parser.add_argument(
+        "--pairs", required=True, type=Path, help="JSONL file of question/answer ids"
+    )
+    parser.add_argument("--k", type=int, default=5, help="Top k hits to consider")
+    args = parser.parse_args()
+
+    retriever = HybridRetriever()
+    for ch in load_jsonl(args.collection):
+        retriever.upsert([ch])
+
+    total = 0
+    recall = 0.0
+    mrr = 0.0
+
+    for qa in load_jsonl(args.pairs):
+        q = qa.get("question", "")
+        rel_ids: List[str] = qa.get("answer_ids") or []
+        if not q or not rel_ids:
+            continue
+        hits = retriever.query([q], k=args.k)
+        hit_ids = [h["id"] for h in hits]
+        # recall@k
+        retrieved = sum(1 for i in rel_ids if i in hit_ids)
+        recall += retrieved / len(rel_ids)
+        # mrr
+        rr = 0.0
+        for rank, hid in enumerate(hit_ids, 1):
+            if hid in rel_ids:
+                rr = 1.0 / rank
+                break
+        mrr += rr
+        total += 1
+
+    if total:
+        print(f"Recall@{args.k}: {recall / total:.4f}")
+        print(f"MRR@{args.k}: {mrr / total:.4f}")
+    else:
+        print("No valid QA pairs found.")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/services/retrieval/__init__.py
+++ b/services/retrieval/__init__.py
@@ -6,6 +6,6 @@ all data in memory so that the surrounding application can evolve without a
 heavy dependency footprint.
 """
 
-from .hybrid import HybridRetriever
+from .hybrid import HybridRetriever, snapshot
 
-__all__ = ["HybridRetriever"]
+__all__ = ["HybridRetriever", "snapshot"]


### PR DESCRIPTION
## Summary
- Add `scripts/evaluate_retrieval.py` to compute Recall@k and MRR from QA pairs
- Implement `snapshot` helper in `services/retrieval.hybrid` to archive collection data
- Document evaluation and snapshot usage in README

## Testing
- `python -m py_compile scripts/evaluate_retrieval.py services/retrieval/hybrid.py services/retrieval/__init__.py`
- `python scripts/evaluate_retrieval.py --help`
- `python -m services.retrieval.hybrid snapshot --help`


------
https://chatgpt.com/codex/tasks/task_e_68afbccd4168832982b87bca67a44ac4