### PR TITLE
Fix search endpoint and expose CollectionManager

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -527,6 +527,13 @@ def search():
     ``query``, ``k``, ``where`` and ``where_document``.
     """
 
+    # Parse request parameters (compatible with Chroma-style JSON)
+    p = request.get_json(silent=True) or {}
+    collection = p.get("collection", "default")
+
+    # Perform the query using the configured CollectionManager
+    res = retriever.query(
+        collection,
         [p.get("query", "")],
         k=p.get("k", 10),
         where=p.get("where"),

--- a/services/retrieval/__init__.py
+++ b/services/retrieval/__init__.py
@@ -6,4 +6,6 @@ all data in memory so that the surrounding application can evolve without a
 heavy dependency footprint.
 """
 from .hybrid import HybridRetriever, snapshot
-__all__ = ["HybridRetriever", "snapshot"]
+from .collection import CollectionManager
+
+__all__ = ["HybridRetriever", "CollectionManager", "snapshot"]


### PR DESCRIPTION
## Summary
- handle JSON parameters in `/search` and invoke `CollectionManager` query correctly
- export `CollectionManager` from retrieval package so imports work

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app_unified.py` (server started)

------
https://chatgpt.com/codex/tasks/task_e_68b03fa35a2883298fbd4ed5b0f985c0