### PR TITLE
feat: allow optional LAN access to full routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ python app.py
 python app_lan.py
 ```
 - 默认仅提供扫描 + AI 接口，文件操作受限  
-- `/full/*` 路由仅允许本机访问（127.0.0.1 / ::1），确保外部无法操作本机文件  
+- `/full/*` 路由默认仅允许本机访问（127.0.0.1 / ::1），可在 `config/settings.json` 中将 `allow_remote_full` 设为 `true` 放开限制
 
 ---
 

--- a/app_lan.py
+++ b/app_lan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# 局域网可访问；/full/* 仍仅限本机（统一入口里已做限制）
+# 局域网可访问；/full/* 默认仅限本机，可在 config/settings.json 中开启 allow_remote_full 放开
 from app_unified import create_app
 from core.config import PORT
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -7,6 +7,7 @@
   "permissions": {
     "admin": 1
   },
+  "allow_remote_full": false,
   "theme": "system",
   "collections": {
     "default": "data/collections/default"


### PR DESCRIPTION
## Summary
- allow bypassing localhost-only `/full/*` restriction when `allow_remote_full` is true
- document new option in README and LAN startup script

## Testing
- `python -m py_compile app_unified.py`
- `python -m py_compile app_lan.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43dc47130832985f0b31a8b77ae77