### PR TITLE
Propagate image keyword extraction errors

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -498,6 +498,9 @@ def keywords_image():
                 upload.save(tmp)
                 tmp_path = tmp.name
             res = extractor.extract(tmp_path)
+            err = res.meta.get("error")
+            if err:
+                return jsonify({"ok": False, "error": err})
             tags = res.meta.get("tags", [])
             return jsonify({"ok": True, "keywords": tags})
         except Exception as e:  # pragma: no cover - runtime failures
@@ -517,9 +520,13 @@ def keywords_image():
             continue
         try:
             res = extractor.extract(p)
-            out[p] = res.meta.get("tags", [])
-        except Exception:
-            out[p] = []
+            err = res.meta.get("error")
+            if err:
+                out[p] = {"ok": False, "error": err}
+            else:
+                out[p] = {"ok": True, "keywords": res.meta.get("tags", [])}
+        except Exception as e:
+            out[p] = {"ok": False, "error": str(e)}
     return jsonify({"ok": True, "keywords": out})
 
 # -------------------- 文件操作 --------------------

--- a/static/app_classic.js
+++ b/static/app_classic.js
@@ -574,12 +574,22 @@
     if(!res.ok){ customConfirm('提取失败：'+res.error).then(()=>{}); return; }
     const j=await res.r.json();
     if(!j.ok){ customConfirm('提取失败：'+(j.error||'')).then(()=>{}); return; }
+    let okCnt=0; const fails=[];
     selected.forEach(cb=>{
-      const kw=j.keywords?.[cb.dataset.path]||[];
+      const info=j.keywords?.[cb.dataset.path];
       const cell=cb.closest('tr')?.querySelector('.kw');
-      if(cell) cell.textContent=Array.isArray(kw)?kw.join('，'):kw;
+      if(!info) return;
+      if(info.ok===false){
+        fails.push(info.error||'');
+        if(cell) cell.textContent='';
+      }else{
+        okCnt++;
+        const kw=info.keywords||[];
+        if(cell) cell.textContent=Array.isArray(kw)?kw.join('，'):kw;
+      }
     });
-    customConfirm(`提取完成：${Object.keys(j.keywords||{}).length} 个文件`).then(()=>{});
+    const failMsg=fails.length?`，失败 ${fails.length} 个：${fails.join('；')}`:'';
+    customConfirm(`提取完成：${okCnt} 个文件${failMsg}`).then(()=>{});
   }
 
   async function onClearKw(){

--- a/static/app_full.js
+++ b/static/app_full.js
@@ -98,12 +98,22 @@
       });
       const j = await r.json();
       if(!j || j.ok===false){ toast('提取失败：'+(j&&j.error||''),'error'); return; }
+      let okCnt=0, failCnt=0;
       cbs.forEach(cb=>{
-        const kw=j.keywords?.[cb.dataset.path]||[];
+        const info=j.keywords?.[cb.dataset.path];
         const cell=cb.closest('tr')?.querySelector('.kw');
-        if(cell) cell.textContent = Array.isArray(kw)? kw.join('，'):kw;
+        if(!info){ return; }
+        if(info.ok===false){
+          failCnt++;
+          if(cell) cell.textContent='';
+          toast('提取失败：'+(info.error||''),'error');
+        }else{
+          okCnt++;
+          const kw=info.keywords||[];
+          if(cell) cell.textContent = Array.isArray(kw)? kw.join('，'):kw;
+        }
       });
-      toast(`提取完成：${Object.keys(j.keywords||{}).length} 个文件`);
+      toast(`提取完成：${okCnt} 个文件${failCnt? '，失败 '+failCnt+' 个':''}`);
     }catch(e){
       toast('提取异常：'+e,'error');
     }

--- a/static/app_lan_plus.js
+++ b/static/app_lan_plus.js
@@ -168,7 +168,9 @@ el("btnGenKW").onclick=async()=>{
       r.kw = data.keywords || [];
       ok++;
     }catch(e){
-      console.error(e); r.kw="❌ 失败"; fail++;
+      console.error(e);
+      r.kw=`❌ 失败: ${e.message||e}`;
+      fail++;
     }
     render();
   }
@@ -193,7 +195,9 @@ el("btnImgKW").onclick=async()=>{
       r.kw = data.keywords || [];
       ok++;
     }catch(e){
-      console.error(e); r.kw="❌ 失败"; fail++;
+      console.error(e);
+      r.kw=`❌ 失败: ${e.message||e}`;
+      fail++;
     }
     render();
   }


### PR DESCRIPTION
## Summary
- Return extractor error details from `/keywords_image` instead of empty keyword lists
- Display per-file keyword extraction errors in classic, full, and LAN+ UIs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb992e3bf08329806ca6b7e3c48a48