### PR TITLE
Handle missing onnxruntime for WD14 plugin

### DIFF
--- a/plugins/image_keywords_wd14/__init__.py
+++ b/plugins/image_keywords_wd14/__init__.py
@@ -111,7 +111,13 @@ class ImageKeywordsWD14:
         elif provider == "cuda":
             providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
 
-        import onnxruntime as ort  # type: ignore
+        try:
+            import onnxruntime as ort  # type: ignore
+        except ModuleNotFoundError as e:  # pragma: no cover - runtime dependency
+            raise ModuleNotFoundError(
+                "onnxruntime is required for image keyword extraction. "
+                "Install it with 'pip install onnxruntime'."
+            ) from e
 
         self._session = ort.InferenceSession(model_path, providers=providers)
 


### PR DESCRIPTION
## Summary
- explain that onnxruntime is required
- raise clear message instructing to install it when missing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbdc1f5b7083299ecfe6be944e31a2