### PR TITLE
Add logging and configurable output for WD14 plugin

### DIFF
--- a/app_unified.py
+++ b/app_unified.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import logging
 from urllib.parse import urlencode
 from flask import Flask, request, abort, redirect, jsonify, session
 from core.settings import SETTINGS
@@ -8,8 +9,22 @@ from core.settings import SETTINGS
 from api.ai import bp as ai_bp            # /api/ai/*
 from api.routes import bp as full_bp      # 我们将把它注册到 /full/*
 
-# 端口配置
-from core.config import PORT
+# 端口配置及日志配置
+from core.config import PORT, LOG_LEVEL, LOG_FILE
+
+
+def _setup_logging() -> None:
+    handlers = [logging.StreamHandler()]
+    if LOG_FILE:
+        handlers.append(logging.FileHandler(LOG_FILE, encoding="utf-8"))
+    logging.basicConfig(
+        level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=handlers,
+    )
+
+
+_setup_logging()
 
 # 旧版前端可能直接请求根路径接口，这里统一做 307 → /full/* 的兼容重写
 ROOT_API_PATHS = {

--- a/config.toml
+++ b/config.toml
@@ -15,3 +15,9 @@ user = "root"
 password = "mem@MS0ry"
 database = "groundhog"
 
+[logging]
+# 日志级别: DEBUG, INFO, WARNING, ERROR
+level = "INFO"
+# 为空则输出到控制台，否则输出到指定文件
+file = ""
+

--- a/config_example.toml
+++ b/config_example.toml
@@ -11,3 +11,9 @@ user = "root"
 password = "your_password"
 database = "groundhog"
 trash_dir = ""
+
+[logging]
+# 日志级别: DEBUG, INFO, WARNING, ERROR
+level = "INFO"
+# 为空则输出到控制台，否则输出到指定文件
+file = ""

--- a/core/config.py
+++ b/core/config.py
@@ -22,3 +22,6 @@ OLLAMA = CFG.get("ollama", {"enable": False, "model":"gpt-oss:20b", "timeout_sec
 MYSQL_CFG = CFG.get("mysql", {"enable": False})
 MYSQL_ENABLED = bool(MYSQL_CFG.get("enable"))
 TRASH_DIR = CFG.get("trash_dir", "")
+LOGGING_CFG = CFG.get("logging", {})
+LOG_LEVEL = LOGGING_CFG.get("level", "INFO")
+LOG_FILE = LOGGING_CFG.get("file", "")


### PR DESCRIPTION
## Summary
- add detailed logging to WD14 image keyword extractor
- log keyword extraction requests in `/keywords_image` route
- allow configuring log level and destination via config

## Testing
- `python -m py_compile api/routes.py app_unified.py core/config.py plugins/image_keywords_wd14/__init__.py`
- `python -m pytest`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask pillow requests` *(fails: Could not find a version that satisfies the requirement flask)*


------
https://chatgpt.com/codex/tasks/task_e_68be7dc8145083299ba99051fbe58b49