### PR TITLE
fix: correct wd14 config path

### DIFF
--- a/plugins/image_keywords_wd14/__init__.py
+++ b/plugins/image_keywords_wd14/__init__.py
@@ -59,7 +59,13 @@ class ImageKeywordsWD14:
 
     # ------------------------------------------------------------------
     def _load_cfg(self) -> dict:
-        cfg_path = Path(__file__).resolve().parents[1] / "config" / "settings.toml"
+        # ``settings.toml`` lives in the repository ``config`` directory which is two
+        # levels up from this file (``plugins/image_keywords_wd14``). Using
+        # ``parents[2]`` ensures the path resolves to ``<repo_root>/config``
+        # irrespective of where the plugin package is imported from.
+        cfg_path = (
+            Path(__file__).resolve().parents[2] / "config" / "settings.toml"
+        )
         if cfg_path.exists():
             with open(cfg_path, "rb") as f:
                 return tomllib.load(f).get("wd14", {})


### PR DESCRIPTION
## Summary
- fix WD14 image keywords plugin to load config from repository root

## Testing
- `pytest`
- `python - <<'PY'
import types, sys, importlib
PIL_stub = types.ModuleType('PIL')
class DummyImage: pass
PIL_stub.Image = DummyImage
sys.modules['PIL'] = PIL_stub
import plugins.image_keywords_wd14 as mod
importlib.reload(mod)
inst = mod.ImageKeywordsWD14()
print(sorted(inst._cfg.keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be8a3a118883298cc6f19eb41c10ef